### PR TITLE
fix: add missing closing bracket when site does not have pages

### DIFF
--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -87,6 +87,9 @@ document.addEventListener("keydown", (e) => {
         .add(
       {{ end }}
     {{ end }}
+    {{ if eq 0 $len }}
+      )
+    {{ end }}
   ;
 
   search.addEventListener("input", function () {


### PR DESCRIPTION
Just closing the bracket properly.

On a new website that does not have any pages yet, it was causing an error:

```
❯ hugo server -v    
Start building sites … 
hugo v0.111.3+extended darwin/arm64 BuildDate=unknown
INFO 2023/05/13 17:42:47 syncing static files to /
INFO 2023/05/13 17:42:47 postcss: use config file <path_to_project>/themes/gruvbox/postcss.config.js
INFO 2023/05/13 17:42:47 postcss: use config file <path_to_project>/themes/gruvbox/postcss.config.js
Error: Error building site: JSBUILD: failed to transform "js/flexsearch.js" (text/javascript): "<path_to_project>/themes/gruvbox/assets/js/flexsearch.js:75:2": Unexpected ";"
Built in 603 ms
```