### PR TITLE
Create a new tag cloud parial

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,16 @@ You can extend the theme by overriding the following partials in the
 - [`comments.html`](./layouts/partials/comments.html)  
   Comments at the end of posts
 
+## Enable the Tag Cloud
+
+The theme comes with a tag cloud partial. It is included in the sidebar, but it is disabled by default. If you wish to enable it, create a new file `data/tag_cloud.json` and add this to it:
+
+```json
+{
+  "tagCloud": true
+}
+```
+
 ## Remove the Sidebar
 
 If you want to get rid of the sidebar, add an empty `data/en.json` file with the

--- a/README.md
+++ b/README.md
@@ -421,7 +421,9 @@ You can extend the theme by overriding the following partials in the
 
 ## Enable the Tag Cloud
 
-The theme comes with a tag cloud partial. It is included in the sidebar, but it is disabled by default. If you wish to enable it, add `enableTagCloud = true` to `[params]` in `config.toml` or `hugo.toml`.
+The theme comes with a tag cloud partial. It is included in the sidebar, but it
+is disabled by default. If you wish to enable it, add `enableTagCloud = true` to
+`[params]` in `config.toml` or `hugo.toml`.
 
 ```toml
 [params]

--- a/README.md
+++ b/README.md
@@ -419,15 +419,17 @@ You can extend the theme by overriding the following partials in the
 - [`comments.html`](./layouts/partials/comments.html)  
   Comments at the end of posts
 
-## Enable the Tag Cloud
+## Configure the Tag Cloud
 
 The theme comes with a tag cloud partial. It is included in the sidebar, but it
-is disabled by default. If you wish to enable it, add `enableTagCloud = true` to
-`[params]` in `config.toml` or `hugo.toml`.
+is disabled by default. If you wish to configure it, add the following to the
+`[params]` section in the `config.toml` file:
 
 ```toml
-[params]
-  enableTagCloud = true
+[params.tagCloud]
+  enable = true
+  minFontSizeRem = 0.8
+  maxFontSizeRem = 1.8
 ```
 
 ## Remove the Sidebar

--- a/README.md
+++ b/README.md
@@ -421,12 +421,11 @@ You can extend the theme by overriding the following partials in the
 
 ## Enable the Tag Cloud
 
-The theme comes with a tag cloud partial. It is included in the sidebar, but it is disabled by default. If you wish to enable it, create a new file `data/tag_cloud.json` and add this to it:
+The theme comes with a tag cloud partial. It is included in the sidebar, but it is disabled by default. If you wish to enable it, add `enableTagCloud = true` to `[params]` in `config.toml` or `hugo.toml`.
 
-```json
-{
-  "tagCloud": true
-}
+```toml
+[params]
+  enableTagCloud = true
 ```
 
 ## Remove the Sidebar

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ is disabled by default. If you wish to configure it, add the following to the
 [params.tagCloud]
   enable = true
   minFontSizeRem = 0.8
-  maxFontSizeRem = 1.8
+  maxFontSizeRem = 2.0
 ```
 
 ## Remove the Sidebar

--- a/assets/css/critical/35-sidebar.css
+++ b/assets/css/critical/35-sidebar.css
@@ -5,6 +5,10 @@
   margin-right: auto;
   padding-left: 2.5rem;
 
+  & hr {
+    margin: 1.5rem auto;
+  }
+
   & svg {
     fill: var(--fg);
   }
@@ -65,8 +69,14 @@ aside.toc {
   }
 }
 
+.tag-cloud {
+  text-align: justify;
+}
+
+.tag-cloud__tag:hover {
+  color: var(--fg3);
+}
+
 .tag-cloud__tag--active {
-  color: var(--fg);
-  background-color: var(--bg2);
-  padding-inline: 0.2rem;
+  text-decoration: underline;
 }

--- a/assets/css/critical/35-sidebar.css
+++ b/assets/css/critical/35-sidebar.css
@@ -70,6 +70,7 @@ aside.toc {
 }
 
 .tag-cloud {
+  line-height: 1.1;
   text-align: justify;
 }
 

--- a/assets/css/critical/35-sidebar.css
+++ b/assets/css/critical/35-sidebar.css
@@ -64,3 +64,9 @@ aside.toc {
     }
   }
 }
+
+.tag-cloud__tag--active {
+  color: var(--fg);
+  background-color: var(--bg2);
+  padding-inline: 0.2rem;
+}

--- a/assets/css/critical/35-tag-cloud.css
+++ b/assets/css/critical/35-tag-cloud.css
@@ -1,0 +1,5 @@
+.tag__active {
+  color: var(--fg);
+  background-color: var(--bg2);
+  padding-inline: 0.2rem;
+}

--- a/assets/css/critical/35-tag-cloud.css
+++ b/assets/css/critical/35-tag-cloud.css
@@ -1,5 +1,0 @@
-.tag__active {
-  color: var(--fg);
-  background-color: var(--bg2);
-  padding-inline: 0.2rem;
-}

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -63,7 +63,7 @@ enableRobotsTXT = true
   [params.tagCloud]
     enable = false
     minFontSizeRem = 0.8
-    maxFontSizeRem = 1.8
+    maxFontSizeRem = 2.0
 
   # Social share links for posts:
   #   - iconSuite: "simple-icon" or "tabler-icon"

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -59,6 +59,11 @@ enableRobotsTXT = true
   #  min = 300
   #  max = 700
   #  increment = 200
+  
+  [params.tagCloud]
+    enable = false
+    minFontSizeRem = 0.8
+    maxFontSizeRem = 1.8
 
   # Social share links for posts:
   #   - iconSuite: "simple-icon" or "tabler-icon"

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -19,7 +19,7 @@
   {{ end }}
 
   {{ if $.Site.Params.enableTagCloud }}
-    <aside class="tag__cloud">
+    <aside>
       {{ partial "tag-cloud.html" . }}
     </aside>
   {{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -18,8 +18,7 @@
     </aside>
   {{ end }}
 
-  {{ $tc := index $.Site.Data.tag_cloud }}
-  {{ if $tc.tagCloud }}
+  {{ if .Site.Params.enableTagCloud }}
     <aside class="tag__cloud">
       {{ partial "tag-cloud.html" . }}
     </aside>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -17,4 +17,11 @@
       {{ partial "json-resume/basics.html" . }}
     </aside>
   {{ end }}
+
+  {{ $tc := index $.Site.Data.tag_cloud }}
+  {{ if $tc.tagCloud }}
+    <aside class="tag__cloud">
+      {{ partial "tag-cloud.html" . }}
+    </aside>
+  {{ end }}
 </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -18,7 +18,7 @@
     </aside>
   {{ end }}
 
-  {{ if .Site.Params.enableTagCloud }}
+  {{ if $.Site.Params.enableTagCloud }}
     <aside class="tag__cloud">
       {{ partial "tag-cloud.html" . }}
     </aside>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -15,10 +15,14 @@
   {{ if $cv.basics }}
     <aside class="bio">
       {{ partial "json-resume/basics.html" . }}
+
+      {{ if $.Site.Params.tagCloud.enable }}
+        <hr />
+      {{ end }}
     </aside>
   {{ end }}
 
-  {{ if $.Site.Params.enableTagCloud }}
+  {{ if $.Site.Params.tagCloud.enable }}
     <aside>
       {{ partial "tag-cloud.html" . }}
     </aside>

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -1,0 +1,28 @@
+{{ if not (eq (len $.Site.Taxonomies.tags) 0) }}
+{{ $fontUnit := "rem" }}
+{{ $largestFontSize := 2.0 }}
+{{ $largestFontSize := 2.5 }}
+{{ $smallestFontSize := 1.0 }}
+{{ $fontSpread := sub $largestFontSize $smallestFontSize }}
+{{ $max := add (len (index $.Site.Taxonomies.tags.ByCount 0).Pages) 1 }}
+{{ $min := len (index $.Site.Taxonomies.tags.ByCount.Reverse 0).Pages }}
+{{ $spread := sub $max $min }}
+{{ $fontStep := div $fontSpread $spread }}
+
+<div id="tag-cloud" style="padding: 5px 15px">
+    {{ range $name, $taxonomy := $.Site.Taxonomies.tags }}
+    {{ $currentTagCount := len $taxonomy.Pages }}
+    {{ $currentFontSize := (add $smallestFontSize (mul (sub $currentTagCount $min) $fontStep) ) }}
+    {{ $count := len $taxonomy.Pages }}
+    {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
+    {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
+    {{ if eq $.Page.Params.title $name -}}
+    <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}" class="tag__active"
+        style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{$name }}</a>
+    {{ else -}}
+    <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}"
+        style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{$name }}</a>
+    {{ end -}}
+    {{ end }}
+</div>
+{{ end }}

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -15,7 +15,7 @@
   {{ $fontStep := div $fontSpread $spread }}
 
 
-  <div id="tag-cloud" style="padding: 5px 15px">
+  <div class="tag-cloud" style="padding: 5px 15px">
     {{ range $name, $taxonomy := $.Site.Taxonomies.tags }}
       {{ $currentTagCount := len $taxonomy.Pages }}
       {{ $currentFontSize := (add $smallestFontSize (mul (sub $currentTagCount $min) $fontStep) ) }}
@@ -26,7 +26,7 @@
         href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}"
         style="font-size:{{ $currentFontSize }}{{ $fontUnit }}"
         {{ if eq $.Page.Params.title $name -}}
-          class="tag__active"
+          class="tag-cloud__tag--active"
         {{ end -}}
         >{{ $name }}</a
       >

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -6,7 +6,7 @@
 {{ with $.Site.Taxonomies.tags }}
   {{ $fontUnit := "rem" }}
   {{ $minFontSize := $.Site.Params.tagCloud.minFontSizeRem | default 0.8 }}
-  {{ $maxFontSize := $.Site.Params.tagCloud.maxFontSizeRem | default 1.8 }}
+  {{ $maxFontSize := $.Site.Params.tagCloud.maxFontSizeRem | default 2.0 }}
   {{ $fontSizeSpread := sub $maxFontSize $minFontSize }}
   {{ $min :=      len (index .ByCount.Reverse 0).Pages }}
   {{ $max := add (len (index .ByCount         0).Pages) 1 }}

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -5,8 +5,8 @@
 
 {{ with $.Site.Taxonomies.tags }}
   {{ $fontUnit := "rem" }}
-  {{ $minFontSize := 1.0 }}
-  {{ $maxFontSize := 2.5 }}
+  {{ $minFontSize := $.Site.Params.tagCloud.minFontSizeRem | default 0.8 }}
+  {{ $maxFontSize := $.Site.Params.tagCloud.maxFontSizeRem | default 1.8 }}
   {{ $fontSizeSpread := sub $maxFontSize $minFontSize }}
   {{ $min :=      len (index .ByCount.Reverse 0).Pages }}
   {{ $max := add (len (index .ByCount         0).Pages) 1 }}

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -3,34 +3,29 @@
   Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/)
 -->
 
-{{ if not (eq (len $.Site.Taxonomies.tags) 0) }}
+{{ with $.Site.Taxonomies.tags }}
   {{ $fontUnit := "rem" }}
-  {{ $largestFontSize := 2.0 }}
-  {{ $largestFontSize := 2.5 }}
-  {{ $smallestFontSize := 1.0 }}
-  {{ $fontSpread := sub $largestFontSize $smallestFontSize }}
-  {{ $max := add (len (index $.Site.Taxonomies.tags.ByCount 0).Pages) 1 }}
-  {{ $min := len (index $.Site.Taxonomies.tags.ByCount.Reverse 0).Pages }}
-  {{ $spread := sub $max $min }}
-  {{ $fontStep := div $fontSpread $spread }}
+  {{ $minFontSize := 1.0 }}
+  {{ $maxFontSize := 2.5 }}
+  {{ $fontSizeSpread := sub $maxFontSize $minFontSize }}
+  {{ $min :=      len (index .ByCount.Reverse 0).Pages }}
+  {{ $max := add (len (index .ByCount         0).Pages) 1 }}
 
 
   <div class="tag-cloud">
-    {{ range $name, $taxonomy := $.Site.Taxonomies.tags }}
-      {{ $currentTagCount := len $taxonomy.Pages }}
-      {{ $currentFontSize := (add $smallestFontSize (mul (sub $currentTagCount $min) $fontStep) ) }}
-      {{ $count := len $taxonomy.Pages }}
-      {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
-      {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
+    {{ range $tagName, $weightedPages := . }}
+      {{ $count := len $weightedPages.Pages }}
+      {{ $weight := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
+      {{ $fontSize := (add $minFontSize (mul $fontSizeSpread $weight) ) }}
       <a
-        href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}"
-        style="font-size:{{ $currentFontSize }}{{ $fontUnit }}"
-        {{ if eq $.Page.Params.title $name -}}
+        href="{{ "/tags/" | relLangURL }}{{ $tagName | urlize }}"
+        style="font-size:{{ $fontSize }}{{ $fontUnit }}"
+        {{ if eq $.Page.Params.title $tagName -}}
           class="tag-cloud__tag tag-cloud__tag--active"
         {{ else -}}
           class="tag-cloud__tag"
         {{ end -}}
-        >{{ $name }}</a
+        >{{ $tagName }}</a
       >
     {{ end }}
   </div>

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -15,7 +15,7 @@
   {{ $fontStep := div $fontSpread $spread }}
 
 
-  <div class="tag-cloud" style="padding: 5px 15px">
+  <div class="tag-cloud">
     {{ range $name, $taxonomy := $.Site.Taxonomies.tags }}
       {{ $currentTagCount := len $taxonomy.Pages }}
       {{ $currentFontSize := (add $smallestFontSize (mul (sub $currentTagCount $min) $fontStep) ) }}
@@ -26,7 +26,9 @@
         href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}"
         style="font-size:{{ $currentFontSize }}{{ $fontUnit }}"
         {{ if eq $.Page.Params.title $name -}}
-          class="tag-cloud__tag--active"
+          class="tag-cloud__tag tag-cloud__tag--active"
+        {{ else -}}
+          class="tag-cloud__tag"
         {{ end -}}
         >{{ $name }}</a
       >

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -4,30 +4,32 @@
 -->
 
 {{ if not (eq (len $.Site.Taxonomies.tags) 0) }}
-{{ $fontUnit := "rem" }}
-{{ $largestFontSize := 2.0 }}
-{{ $largestFontSize := 2.5 }}
-{{ $smallestFontSize := 1.0 }}
-{{ $fontSpread := sub $largestFontSize $smallestFontSize }}
-{{ $max := add (len (index $.Site.Taxonomies.tags.ByCount 0).Pages) 1 }}
-{{ $min := len (index $.Site.Taxonomies.tags.ByCount.Reverse 0).Pages }}
-{{ $spread := sub $max $min }}
-{{ $fontStep := div $fontSpread $spread }}
+  {{ $fontUnit := "rem" }}
+  {{ $largestFontSize := 2.0 }}
+  {{ $largestFontSize := 2.5 }}
+  {{ $smallestFontSize := 1.0 }}
+  {{ $fontSpread := sub $largestFontSize $smallestFontSize }}
+  {{ $max := add (len (index $.Site.Taxonomies.tags.ByCount 0).Pages) 1 }}
+  {{ $min := len (index $.Site.Taxonomies.tags.ByCount.Reverse 0).Pages }}
+  {{ $spread := sub $max $min }}
+  {{ $fontStep := div $fontSpread $spread }}
 
-<div id="tag-cloud" style="padding: 5px 15px">
+
+  <div id="tag-cloud" style="padding: 5px 15px">
     {{ range $name, $taxonomy := $.Site.Taxonomies.tags }}
-    {{ $currentTagCount := len $taxonomy.Pages }}
-    {{ $currentFontSize := (add $smallestFontSize (mul (sub $currentTagCount $min) $fontStep) ) }}
-    {{ $count := len $taxonomy.Pages }}
-    {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
-    {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
-    {{ if eq $.Page.Params.title $name -}}
-    <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}" class="tag__active"
-        style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{$name }}</a>
-    {{ else -}}
-    <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}"
-        style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{$name }}</a>
-    {{ end -}}
+      {{ $currentTagCount := len $taxonomy.Pages }}
+      {{ $currentFontSize := (add $smallestFontSize (mul (sub $currentTagCount $min) $fontStep) ) }}
+      {{ $count := len $taxonomy.Pages }}
+      {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
+      {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
+      <a
+        href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}"
+        style="font-size:{{ $currentFontSize }}{{ $fontUnit }}"
+        {{ if eq $.Page.Params.title $name -}}
+          class="tag__active"
+        {{ end -}}
+        >{{ $name }}</a
+      >
     {{ end }}
-</div>
+  </div>
 {{ end }}

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -1,3 +1,8 @@
+<!-- 
+  Original work by Artem Sidorenko: https://www.sidorenko.io/post/2017/07/nice-tagcloud-with-hugo/
+  Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/)
+-->
+
 {{ if not (eq (len $.Site.Taxonomies.tags) 0) }}
 {{ $fontUnit := "rem" }}
 {{ $largestFontSize := 2.0 }}


### PR DESCRIPTION
This pull request addresses issue https://github.com/schnerring/hugo-theme-gruvbox/issues/18. The tag cloud is optional and off by default. I have not tested it with a particularly large data set, but this is what it produces with about 20 articles:
![Preview of word cloud](https://github.com/schnerring/hugo-theme-gruvbox/assets/37796862/fb4c7526-c900-4914-a231-ba8e481f5b15)

I wrote a quick [program to generate a bunch of articles](https://gist.github.com/keystroke3/5811e4a156c02c95e33bd855f919fb63). It's not most elegant thing in the world, but it worked. You can use it to test as well.

I have not updated any of the marketing material as I am not sure how to do that properly.